### PR TITLE
Cooldown trigger for Ammunition 

### DIFF
--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Factory/Bullets/BulletFactory.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Factory/Bullets/BulletFactory.cs
@@ -367,7 +367,7 @@ namespace Combat.Factory
             public Result Create(BulletTrigger_PlaySfx trigger)
             {
                 var condition = FromTriggerCondition(trigger.Condition);
-                CreateSoundEffect(_bullet, trigger.AudioClip, condition);
+                CreateSoundEffect(_bullet, trigger.AudioClip, condition, trigger.Cooldown);
                 CreateVisualEffect(_bullet, _collisionBehaviour, condition, trigger);
                 return Result.Ok;
             }
@@ -375,7 +375,7 @@ namespace Combat.Factory
             public Result Create(BulletTrigger_SpawnStaticSfx trigger)
             {
                 var condition = FromTriggerCondition(trigger.Condition);
-                CreateSoundEffect(_bullet, trigger.AudioClip, condition);
+                CreateSoundEffect(_bullet, trigger.AudioClip, condition, trigger.Cooldown);
                 CreateStaticVisualEffect(_bullet, condition, trigger);
                 return Result.Ok;
             }
@@ -409,14 +409,14 @@ namespace Combat.Factory
                 return Result.Ok;
             }
 
-            private void CreateSoundEffect(Bullet bullet, AudioClipId audioClip, ConditionType condition)
+            private void CreateSoundEffect(Bullet bullet, AudioClipId audioClip, ConditionType condition, float cooldown)
             {
                 if (!audioClip) return;
 
 				if (condition == ConditionType.None && !audioClip.Loop)
                     _factory._soundPlayer.Play(audioClip);
                 else
-                    bullet.AddAction(new PlaySoundAction(_factory._soundPlayer, audioClip, condition));
+                    bullet.AddAction(new PlaySoundAction(_factory._soundPlayer, cooldown, audioClip, condition));
             }
 
             private void CreateVisualEffect(Bullet bullet, BulletCollisionBehaviour collisionBehaviour,
@@ -431,7 +431,7 @@ namespace Combat.Factory
                     collisionBehaviour.AddAction(new ShowHitEffectAction(_factory._effectFactory, trigger.VisualEffect, color,
                         size * _factory._stats.BodySize, trigger.Lifetime));
                 else
-                    bullet.AddAction(new PlayEffectAction(bullet, _factory._effectFactory, trigger.VisualEffect, color, size,
+                    bullet.AddAction(new PlayEffectAction(bullet, _factory._effectFactory, trigger.Cooldown, trigger.VisualEffect, color, size,
                         trigger.Lifetime, condition));
             }
 
@@ -441,7 +441,7 @@ namespace Combat.Factory
 
                 var color = trigger.ColorMode.Apply(trigger.Color, _factory._stats.Color);
 
-                bullet.AddAction(new SpawnEffectAction(bullet, _factory._effectFactory, trigger.VisualEffect, color, trigger.Size,
+                bullet.AddAction(new SpawnEffectAction(bullet, _factory._effectFactory, trigger.Cooldown, trigger.VisualEffect, color, trigger.Size,
                     trigger.Lifetime, condition));
             }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Factory/Bullets/BulletFactory.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Factory/Bullets/BulletFactory.cs
@@ -357,6 +357,8 @@ namespace Combat.Factory
                         return ConditionType.OnExpire;
                     case BulletTriggerCondition.Detonated:
                         return ConditionType.OnDetonate;
+                    case BulletTriggerCondition.Cooldown:
+                        return ConditionType.OnCooldown;
                     default:
                         return ConditionType.None;
                 }

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Factory/Bullets/BulletFactoryObsolete.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Factory/Bullets/BulletFactoryObsolete.cs
@@ -96,7 +96,7 @@ namespace Combat.Factory
             if (_stats.FireSound)
             {
                 if (_stats.FireSound.Loop)
-                    bullet.AddAction(new PlaySoundAction(_soundPlayer, _stats.FireSound, ConditionType.None));
+                    bullet.AddAction(new PlaySoundAction(_soundPlayer, 0, _stats.FireSound, ConditionType.None));
                 else
                     _soundPlayer.Play(_stats.FireSound);
             }
@@ -256,7 +256,7 @@ namespace Combat.Factory
         {
             var explodeCondition = _stats.AmmunitionClass.DetonateIfExpired() ? ConditionType.OnExpire | ConditionType.OnDetonate : ConditionType.OnDetonate;
             if (_stats.HitSound)
-                bullet.AddAction(new PlaySoundAction(_soundPlayer, _stats.HitSound, explodeCondition));
+                bullet.AddAction(new PlaySoundAction(_soundPlayer, 0, _stats.HitSound, explodeCondition));
 
             if (_stats.AmmunitionClass.ExplodeIfDetonated(_stats))
                 if (_stats.DamageType == DamageType.Impact)

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/ConditionType.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/ConditionType.cs
@@ -11,6 +11,7 @@ namespace Combat.Component.Bullet.Action
         OnExpire    = 4,
         OnDisarm    = 8,
         OnDestroy   = 16,
+        OnCooldown  = 32,
     }
 
     public static class ConditionTypeExtensions

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateCloudAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateCloudAction.cs
@@ -21,6 +21,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateEmpAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateEmpAction.cs
@@ -21,6 +21,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateExplosionAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateExplosionAction.cs
@@ -19,6 +19,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() {}
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateFlashAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateFlashAction.cs
@@ -19,6 +19,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateGravitationAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateGravitationAction.cs
@@ -22,6 +22,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreatePlasmaWebAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreatePlasmaWebAction.cs
@@ -21,6 +21,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateSmokeExplosionAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateSmokeExplosionAction.cs
@@ -19,6 +19,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateStrongExplosionAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/CreateStrongExplosionAction.cs
@@ -19,6 +19,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/DetonateAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/DetonateAction.cs
@@ -10,6 +10,7 @@ namespace Combat.Component.Bullet.Action
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() { }
 

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/IAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/IAction.cs
@@ -6,6 +6,7 @@ namespace Combat.Component.Bullet.Action
     public interface IAction : IDisposable
     {
         ConditionType Condition { get; }
+        float Cooldown { get; set; }
         CollisionEffect Invoke();
     }
 }

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/PlaySoundAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/PlaySoundAction.cs
@@ -1,23 +1,33 @@
 ﻿using Combat.Collision;
 using GameDatabase.Model;
 using Services.Audio;
+using UnityEngine;
 
 namespace Combat.Component.Bullet.Action
 {
     public class PlaySoundAction : IAction
     {
-        public PlaySoundAction(ISoundPlayer soundPlayer, AudioClipId audioClipId, ConditionType condition)
+        public PlaySoundAction(ISoundPlayer soundPlayer, float cooldown, AudioClipId audioClipId, ConditionType condition)
         {
             _soundPlayer = soundPlayer;
             _audioClipId = audioClipId;
             _condition = condition;
+            Cooldown = cooldown;
         }
 
         public ConditionType Condition { get { return _condition; } }
+        public float Cooldown { get; set; }
 
         public CollisionEffect Invoke()
         {
+            var time = Time.fixedTime;
+
+            if (time < _nextActivation)
+                return CollisionEffect.None;
+            
             Play();
+
+            _nextActivation = time + Cooldown;
             return CollisionEffect.None;
         }
 
@@ -32,6 +42,7 @@ namespace Combat.Component.Bullet.Action
             _soundPlayer.Play(_audioClipId, GetHashCode());
         }
 
+        private float _nextActivation;
         private readonly ConditionType _condition;
         private readonly ISoundPlayer _soundPlayer;
         private readonly AudioClipId _audioClipId;

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/SpawnEffectAction.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Action/SpawnEffectAction.cs
@@ -10,7 +10,7 @@ namespace Combat.Component.Bullet.Action
 {
     public class SpawnEffectAction : IAction
     {
-        public SpawnEffectAction(IUnit unit, EffectFactory effectFactory, VisualEffect effectData, Color color, float size, float lifetime, ConditionType condition)
+        public SpawnEffectAction(IUnit unit, EffectFactory effectFactory, float cooldown, VisualEffect effectData, Color color, float size, float lifetime, ConditionType condition)
         {
             _effectFactory = effectFactory;
             _unit = unit;
@@ -19,25 +19,36 @@ namespace Combat.Component.Bullet.Action
             _size = size;
             _lifetime = lifetime;
             Condition = condition;
+            Cooldown = cooldown;
         }
 
         public ConditionType Condition { get; private set; }
+        public float Cooldown { get; set; }
 
         public void Dispose() {}
 
         public CollisionEffect Invoke()
         {
+            var time = Time.fixedTime;
+
+            if (time < _nextActivation)
+                return CollisionEffect.None;
+            
             var effect = CompositeEffect.Create(_visualEffect, _effectFactory, null);
             effect.Position = _unit.Body.WorldPosition();
             effect.Rotation = _unit.Body.WorldRotation();
             effect.Color = _color;
             effect.Size = _size;
             effect.Run(_lifetime, Vector2.zero, 0);
+
+            _nextActivation = time + Cooldown;
+            
             return CollisionEffect.None;
         }
 
         private readonly IUnit _unit;
 
+        private float _nextActivation;
         private readonly float _lifetime;
         private readonly Color _color;
         private readonly float _size;

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers.meta
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4142b020a07649ebbf782d08f1cd19fc
+timeCreated: 1706266679

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ActionTicker.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ActionTicker.cs
@@ -1,0 +1,37 @@
+using Combat.Component.Bullet.Tickers;
+
+namespace Combat.Component.Bullet.Action
+{
+    /// <summary>
+    /// A ticker that triggers a specified <see cref="IAction"/>.
+    /// </summary>
+    public class ActionTicker : ITicker
+    {
+        /// <param name="cooldown">The cooldown time in seconds between activations.</param>
+        /// <param name="time">The current time.</param>
+        /// <param name="action">The action to be performed on activation.</param>
+        /// <remarks>
+        /// This constructor should be called with a fixed time value (e.g., <c>Time.fixedTime</c>) to ensure consistent
+        /// behavior.
+        /// </remarks>
+        public ActionTicker(float cooldown, float time, IAction action)
+        {
+            Cooldown = cooldown;
+            NextActivation = time + cooldown;
+        }
+
+        public void Dispose()
+        {
+            _action.Dispose();
+        }
+
+        public float Cooldown { get; }
+        public float NextActivation { get; set; }
+        public void Activate()
+        {
+            _action.Invoke(); // Collision effect is discarded, same as in `Created` condition
+        }
+        
+        private readonly IAction _action;
+    }
+}

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ActionTicker.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ActionTicker.cs
@@ -1,4 +1,5 @@
 using Combat.Component.Bullet.Tickers;
+using UnityEngine;
 
 namespace Combat.Component.Bullet.Action
 {
@@ -18,6 +19,7 @@ namespace Combat.Component.Bullet.Action
         {
             Cooldown = cooldown;
             NextActivation = time + cooldown;
+            _action = action;
         }
 
         public void Dispose()

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ActionTicker.cs.meta
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ActionTicker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: da741a5d69ef405ba89b3bc69829cd4a
+timeCreated: 1706266490

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITicker.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITicker.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Combat.Component.Bullet.Tickers
+{
+    /// <summary>
+    /// Represents an interface for a ticker object that controls timed activations.
+    /// </summary>
+    public interface ITicker : IDisposable
+    {
+        /// <summary>
+        /// Gets the cooldown time in seconds between activations.
+        /// </summary>
+        /// <value>
+        /// The cooldown duration as a float.
+        /// </value>
+        float Cooldown { get; }
+
+        /// <summary>
+        /// Gets or sets the moment in time (as a float) when the next activation should occur.
+        /// </summary>
+        /// <value>
+        /// Time of the next activation.
+        /// </value>
+        float NextActivation { get; set; }
+
+        /// <summary>
+        /// Activates the ticker, performing its associated action immediately.
+        /// </summary>
+        void Activate();
+    }
+}

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITicker.cs.meta
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITicker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e1cd648a4a8a4c99ba1fc6cc44b2dc4b
+timeCreated: 1706266688

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITickerExtensions.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITickerExtensions.cs
@@ -1,0 +1,26 @@
+namespace Combat.Component.Bullet.Tickers
+{
+    public static class ITickerExtensions
+    {
+        /// <summary>
+        /// Extension method for updating an ITicker instance. This method checks if the ticker is ready for activation
+        /// based on the given time and, if so, activates it.
+        /// </summary>
+        /// <param name="ticker">The ITicker instance to be updated.</param>
+        /// <param name="time">The current time.</param>
+        /// <remarks>
+        /// This method should be called with a fixed time value (e.g., <c>Time.fixedTime</c>) to ensure consistent
+        /// behavior.
+        /// </remarks>
+        public static void Update(this ITicker ticker, float time)
+        {
+            // If the next activation time is not yet reached, return without activating.
+            if (ticker.NextActivation < time) return;
+
+            // Activate the ticker and set the next activation time.
+            ticker.Activate();
+            ticker.NextActivation = time + ticker.Cooldown;
+        }
+
+    }
+}

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITickerExtensions.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITickerExtensions.cs
@@ -1,3 +1,5 @@
+using GameDiagnostics;
+
 namespace Combat.Component.Bullet.Tickers
 {
     public static class ITickerExtensions
@@ -15,7 +17,7 @@ namespace Combat.Component.Bullet.Tickers
         public static void Update(this ITicker ticker, float time)
         {
             // If the next activation time is not yet reached, return without activating.
-            if (ticker.NextActivation < time) return;
+            if (time < ticker.NextActivation) return;
 
             // Activate the ticker and set the next activation time.
             ticker.Activate();

--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITickerExtensions.cs.meta
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Unit/Bullet/Tickers/ITickerExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2486c74336fe43528563028f66a0975a
+timeCreated: 1706266895

--- a/Assets/Modules/Database/.Schema/v1/Enums/Weapon/BulletTriggerCondition.xml
+++ b/Assets/Modules/Database/.Schema/v1/Enums/Weapon/BulletTriggerCondition.xml
@@ -8,4 +8,5 @@
     <item name="Expired" />
     <item name="Detonated" />
     <item name="OutOfAmmo" />
+    <item name="Cooldown" />
 </data>

--- a/Assets/Modules/Database/.Schema/v1/Objects/Weapon/BulletTrigger.xml
+++ b/Assets/Modules/Database/.Schema/v1/Objects/Weapon/BulletTrigger.xml
@@ -10,7 +10,7 @@
     <member name="Quantity" type="int" minvalue="0" maxvalue="1000" case="SpawnBullet" />
     <member name="Size" type="float" minvalue="0" maxvalue="100" case="PlaySfx,SpawnStaticSfx,SpawnBullet,GravityField" />
     <member name="Lifetime" type="float" minvalue="0" maxvalue="1000" case="PlaySfx,SpawnStaticSfx" />
-    <member name="Cooldown" type="float" minvalue="0" maxvalue="1000" case="SpawnBullet" />
+    <member name="Cooldown" type="float" minvalue="0" maxvalue="1000" />
     <member name="RandomFactor" type="float" minvalue="0" maxvalue="1" case="SpawnBullet" />
     <member name="PowerMultiplier" type="float" minvalue="0" maxvalue="1000" case="SpawnBullet,GravityField" />
     <member name="MaxNestingLevel" type="int" minvalue="0" maxvalue="100" case="SpawnBullet" />

--- a/Assets/Modules/Database/Scripts/GeneratedGameCode/DataModel/BulletTrigger.cs
+++ b/Assets/Modules/Database/Scripts/GeneratedGameCode/DataModel/BulletTrigger.cs
@@ -46,12 +46,14 @@ namespace GameDatabase.DataModel
 		{
 			Condition = serializable.Condition;
 			EffectType = serializable.EffectType;
+			Cooldown = UnityEngine.Mathf.Clamp(serializable.Cooldown, 0f, 1000f);
 
 			OnDataDeserialized(serializable, loader);
 		}
 
 		public BulletTriggerCondition Condition { get; private set; }
 		public BulletEffectType EffectType { get; private set; }
+		public float Cooldown { get; private set; }
 
 		public static BulletTrigger DefaultValue { get; private set; } = Create(new(), null);
 	}
@@ -125,7 +127,6 @@ namespace GameDatabase.DataModel
 			ColorMode = serializable.ColorMode;
 			Quantity = UnityEngine.Mathf.Clamp(serializable.Quantity, 0, 1000);
 			Size = UnityEngine.Mathf.Clamp(serializable.Size, 0f, 100f);
-			Cooldown = UnityEngine.Mathf.Clamp(serializable.Cooldown, 0f, 1000f);
 			RandomFactor = UnityEngine.Mathf.Clamp(serializable.RandomFactor, 0f, 1f);
 			PowerMultiplier = UnityEngine.Mathf.Clamp(serializable.PowerMultiplier, 0f, 1000f);
 			MaxNestingLevel = UnityEngine.Mathf.Clamp(serializable.MaxNestingLevel, 0, 100);
@@ -144,7 +145,6 @@ namespace GameDatabase.DataModel
 		public ColorMode ColorMode { get; private set; }
 		public int Quantity { get; private set; }
 		public float Size { get; private set; }
-		public float Cooldown { get; private set; }
 		public float RandomFactor { get; private set; }
 		public float PowerMultiplier { get; private set; }
 		public int MaxNestingLevel { get; private set; }

--- a/Assets/Modules/Database/Scripts/GeneratedGameCode/Enums/BulletTriggerCondition.cs
+++ b/Assets/Modules/Database/Scripts/GeneratedGameCode/Enums/BulletTriggerCondition.cs
@@ -18,5 +18,6 @@ namespace GameDatabase.Enums
 		Expired,
 		Detonated,
 		OutOfAmmo,
+		Cooldown,
 	}
 }


### PR DESCRIPTION
This PR is aimed at adding Cooldown trigger condition to the "new" ammunition system.

## Motivation:
In mods, there is often a need to make an ammo that does something every X seconds, but currently the only way to implement it is to use recursion, which limits the amount of activations, as well leads to other issues. This PR allows to just specify a Cooldown trigger, and specify interval in Cooldown field, and this trigger will get invoked at a specified interval.

## Side effects
As a side effect of implementing this PR, all triggers of "new" ammunition now support Cooldown field usage, just like SpawnBullet did previously.

## Performance considerations
This PR was made with performance in mind. I tried my best to limit the amount of processing required during combat. Cooldown-triggered actions use a separate system that I called `ITicker`, which leads to less processing than just emitting "OnCooldown" every frame to all actions.