### PR TITLE
Power field support for fortification device

### DIFF
--- a/Assets/Modules/BattleSimulator/Scripts/Combat/Component/Systems/Devices/FortificationDevice.cs
+++ b/Assets/Modules/BattleSimulator/Scripts/Combat/Component/Systems/Devices/FortificationDevice.cs
@@ -19,6 +19,12 @@ namespace Combat.Component.Systems.Devices
             _ship = ship;
             _activeColor = deviceSpec.Color;
             _energyCost = deviceSpec.EnergyConsumption;
+
+            _power = deviceSpec.Power / 100;
+            if (_power == 0)
+            {
+                _power = 0.5f;
+            }
         }
 
 		public GameDatabase.Enums.DeviceClass DeviceClass { get; }
@@ -29,9 +35,15 @@ namespace Combat.Component.Systems.Devices
         {
             if (_isEnabled)
             {
-                data.Energy = 0.5f + data.Energy*0.5f;
-                data.Heat = 0.5f + data.Heat * 0.5f;
-                data.Kinetic = 0.5f + data.Kinetic * 0.5f;
+                // We don't want to get into weird territory with the original
+                // resistances, so in case if the fortification device has
+                // power over 1, the original ship resistances are just
+                // ignored, since the multiplier is clamped to 0
+                var resMult = Mathf.Clamp01(1 - _power);
+                
+                data.Energy = _power + data.Energy * resMult;
+                data.Heat = _power + data.Heat * resMult;
+                data.Kinetic = _power + data.Kinetic * resMult;
             }
 
             return true;
@@ -82,6 +94,7 @@ namespace Combat.Component.Systems.Devices
         private Color _color = Color.white;
         private readonly Color _activeColor;
         private readonly float _energyCost;
+        private readonly float _power;
         private readonly IShip _ship;
     }
 }


### PR DESCRIPTION
This PR adds the Power field to the fortification device

## Motivation:
Fortification device, as well as many other devices, are currently rather inflexible. In this particular case, I felt it would be nice to have the ability to modify fortification device power.

## Side effects:
Should be none. If the `Power` field of the fortification device is left at 0, then it will default to an old behavior, identical to specifying power as `50`

## Follow-up work:
Ideally, the `Device` object type should be made into a "switch-object", letting each device type to have its own fields and default values, but I don't have enough spare time to tackle such a large-scale change in the foreseeable future.