### PR TITLE
LootItem requirements

### DIFF
--- a/Assets/Modules/Database/.Schema/v1/Objects/Quests/LootItem.xml
+++ b/Assets/Modules/Database/.Schema/v1/Objects/Quests/LootItem.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data name="LootItem" type="struct" >
     <member name="Weight" type="float" />
+    <member name="Requirement" type="struct" typeid="Requirement" />
     <member name="Loot" type="struct" typeid="LootContent" />
 </data>

--- a/Assets/Modules/Database/Scripts/GeneratedGameCode/DataModel/LootItem.cs
+++ b/Assets/Modules/Database/Scripts/GeneratedGameCode/DataModel/LootItem.cs
@@ -25,12 +25,14 @@ namespace GameDatabase.DataModel
 		private LootItem(LootItemSerializable serializable, Database.Loader loader)
 		{
 			Weight = UnityEngine.Mathf.Clamp(serializable.Weight, -3.402823E+38f, 3.402823E+38f);
+			Requirement = Requirement.Create(serializable.Requirement, loader);
 			Loot = LootContent.Create(serializable.Loot, loader);
 
 			OnDataDeserialized(serializable, loader);
 		}
 
 		public float Weight { get; private set; }
+		public Requirement Requirement { get; private set; }
 		public LootContent Loot { get; private set; }
 
 		public static LootItem DefaultValue { get; private set; }= new(new(), null);

--- a/Assets/Modules/Database/Scripts/GeneratedGameCode/Serializable/LootItem.cs
+++ b/Assets/Modules/Database/Scripts/GeneratedGameCode/Serializable/LootItem.cs
@@ -16,6 +16,7 @@ namespace GameDatabase.Serializable
 	public class LootItemSerializable
 	{
 		public float Weight;
+		public RequirementSerializable Requirement;
 		public LootContentSerializable Loot;
 	}
 }

--- a/Assets/Modules/Database/Scripts/Types/ImmutableCollection.cs
+++ b/Assets/Modules/Database/Scripts/Types/ImmutableCollection.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace GameDatabase.Model
 {
-    public readonly struct ImmutableCollection<T> : IReadOnlyCollection<T>
+    public readonly struct ImmutableCollection<T> : IReadOnlyList<T>
     {
         public static readonly ImmutableCollection<T> Empty = new();
         private readonly List<T> _items;

--- a/Assets/Modules/Quests/Scripts/Factory/Cache.cs
+++ b/Assets/Modules/Quests/Scripts/Factory/Cache.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GameDatabase;
 using GameDatabase.DataModel;
-using UnityEngine.Assertions;
+using GameDiagnostics;
+using Assert = UnityEngine.Assertions.Assert;
 
 namespace Domain.Quests
 {
@@ -125,6 +127,11 @@ namespace Domain.Quests
             _database = database;
         }
 
+        public void SetRequirementCache(IRequirementCache requirementCache)
+        {
+            _requirementCache = requirementCache;
+        }
+
         public ILoot Get(LootModel loot, QuestInfo questInfo)
         {
             if (loot == null) return null;
@@ -134,7 +141,7 @@ namespace Domain.Quests
             ILoot value;
             if (!_cache.TryGetValue(key, out value))
             {
-                value = new Loot(loot, questInfo, _lootItemFactory, _database);
+                value = new Loot(loot, questInfo, _lootItemFactory,  _requirementCache, _database);
                 _cache.Add(key, value);
             }
 
@@ -144,5 +151,6 @@ namespace Domain.Quests
         private readonly IDatabase _database;
         private readonly ILootItemFactory _lootItemFactory;
         private readonly Dictionary<Key<LootModel>, ILoot> _cache = new Dictionary<Key<LootModel>, ILoot>();
+        private IRequirementCache _requirementCache;
     }
 }

--- a/Assets/Modules/Quests/Scripts/Factory/QuestBuilder.cs
+++ b/Assets/Modules/Quests/Scripts/Factory/QuestBuilder.cs
@@ -16,8 +16,9 @@ namespace Domain.Quests
             _seed = seed;
             _context = context;
             _lootCache = new LootCache(context.LootItemFactory, context.Database);
-            _enemyCache = new EnemyCache(context.Database);
             _requirementCache = new RequirementCache(_context, _lootCache);
+            _lootCache.SetRequirementCache(_requirementCache);
+            _enemyCache = new EnemyCache(context.Database);
             _parameters = new QuestInfo(_model, _context.StarMapDataProvider.GetStarData(_starId), seed);
         }
 

--- a/Assets/Scripts/GameStateMachine/States/StartingNewGameState.cs
+++ b/Assets/Scripts/GameStateMachine/States/StartingNewGameState.cs
@@ -57,7 +57,10 @@ namespace GameStateMachine.States
         {
             if (_database.GalaxySettings.StartingInventory == null) return;
 
-            var inventory = new Loot(new LootModel(_database.GalaxySettings.StartingInventory.Loot), new QuestInfo(0), _lootItemFactory, _database);
+            var inventory = new Loot(new LootModel(_database.GalaxySettings.StartingInventory.Loot), new QuestInfo(0),
+                _lootItemFactory,
+                new DummyRequirementCache(
+                    "Loot requirements are not available during startup inventory initialization"), _database);
             foreach (var item in inventory.Items)
                 item.Type.Consume(item.Quantity);
         }

--- a/Assets/Scripts/Legacy/Debug/DatabaseCodesProcessor.cs
+++ b/Assets/Scripts/Legacy/Debug/DatabaseCodesProcessor.cs
@@ -34,7 +34,8 @@ public class DatabaseCodesProcessor
 
     private IEnumerable<IProduct> CreateProducts(LootContent content)
     {
-        var loot = new Loot(new LootModel(content), new QuestInfo(0), _lootItemFactory, _database);
+        var loot = new Loot(new LootModel(content), new QuestInfo(0), _lootItemFactory,
+            new DummyRequirementCache("Loot requirements are not available for debug codes loot"), _database);
         return loot.Items.Select(item => CommonProduct.Create(item.Type, item.Quantity));
     }
 }


### PR DESCRIPTION
This PR adds requirements support to `RandomItems`, `AllItems`, and `ItemsWithChance` loot types

Additionally, it fixes the issue where `RandomItems` could return fewer items than specified by `MinAmount`, as well as improving behavior regarding the bias.

## Motivation:
1. In more complicated quest systems, it's sometimes required to give the player a bunch of loot based on specific requirements. The current approach is to reward the loot in separate quest nodes, but this leads to longer more cluttered quests, where multiple nodes are required to perform what's essentially a single operation. This PR addresses this by allowing mod makers to specify quest requirements in the loot files themselves. It directly reuses the quest requirements system to achieve this, requiring no extra learning.
2. `RandomItems` was broken for a long time. It was easy to get into a situation where it would return fewer items than the minimum amount (for example, requesting 2 items with nodes that have weights `0.1, 0.1, 3`), as well as having bias issues due to the algorithm selecting nodes in a non-rigorous way. This PR changes this to use a weighted shuffle approach, which eliminates bias and guarantees that it will pick exactly as many items as specified by the boundaries.

## Side Effects
1. No breaking changes are expected due to schema change. Existing mods will continue to work because their loot will default to an empty requirement, which is always true.
2. Existing mods that use `RandomItems` will experience a slight change in behavior due to the algorithm getting fixed, but I don't expect this to affect mod balancing in any noticeable way.

## Follow-up work:
1. I plan to open a PR next that adds a loot node which allows inclusion of other loot files into it. This would allow building more complex loot systems and splitting them up into multiple files.
2. The fleet system requires some improvements in a similar vein. Since it's a larger change I have opened an RFC first at #428 and currently awaiting comments and approval