### PR TITLE
feat: incorporate custom double-module slot types

### DIFF
--- a/Assets/Modules/Database/Scripts/GeneratedGameCode/Enums/CellType.cs
+++ b/Assets/Modules/Database/Scripts/GeneratedGameCode/Enums/CellType.cs
@@ -11,10 +11,24 @@ namespace GameDatabase.Enums
 	public enum CellType
 	{
 		Empty = '0',
-		Weapon = '4',
 		Outer = '1',
 		Inner = '2',
-		InnerOuter = '3',
-		Engine = '5',
-	}
+        Weapon = '4',
+        Engine = '5',
+
+        InnerOuter = '3',
+
+        OuterEngine = '6',
+        InnerEngine = '7',
+
+        WeaponOuter = '8',
+        WeaponInner = '9',
+        WeaponEngine = '.',
+
+
+
+        All = 'a',
+
+
+    }
 }

--- a/Assets/Modules/Database/Scripts/Utils/BarrelConverter.cs
+++ b/Assets/Modules/Database/Scripts/Utils/BarrelConverter.cs
@@ -29,7 +29,7 @@ namespace GameDatabase.Utils
         {
             var index = 0;
             var size = layout.Size;
-            var barrels = layout.Data.Select(item => item == (char)CellType.Weapon ? index++ : -1).ToArray();
+            var barrels = layout.Data.Select(item => (item == (char)CellType.Weapon || item == (char)CellType.All || item == (char)CellType.WeaponInner || item == (char)CellType.WeaponOuter || item == (char)CellType.WeaponEngine) ? index++ : -1).ToArray();
 
             for (var k = 0; k < 1000; ++k)
             {

--- a/Assets/Modules/ShipConstructor/Scripts/CellType.cs
+++ b/Assets/Modules/ShipConstructor/Scripts/CellType.cs
@@ -11,10 +11,45 @@ namespace Constructor
 				return false;
 			if (component == CellType.Empty || component == target)
 				return true;
+			
 			if (target == CellType.InnerOuter && (component == CellType.Inner || component == CellType.Outer))
 				return true;
             if (component == CellType.InnerOuter && (target == CellType.Inner || target == CellType.Outer))
                 return true;
+
+            if (target == CellType.OuterEngine && (component == CellType.Engine || component == CellType.Outer))
+                return true;
+            if (component == CellType.OuterEngine && (target == CellType.Engine || target == CellType.Outer))
+                return true;
+
+            if (target == CellType.OuterEngine && (component == CellType.Engine || component == CellType.Outer))
+                return true;
+            if (component == CellType.OuterEngine && (target == CellType.Engine || target == CellType.Outer))
+                return true;
+
+            if (target == CellType.InnerEngine && (component == CellType.Engine || component == CellType.Inner))
+                return true;
+            if (component == CellType.InnerEngine && (target == CellType.Engine || target == CellType.Inner))
+                return true;
+
+            if (target == CellType.WeaponEngine && (component == CellType.Engine || component == CellType.Weapon))
+                return true;
+            if (component == CellType.WeaponEngine && (target == CellType.Engine || target == CellType.Weapon))
+                return true;
+
+            if (target == CellType.WeaponInner && (component == CellType.Inner || component == CellType.Weapon))
+                return true;
+            if (component == CellType.WeaponInner && (target == CellType.Inner || target == CellType.Weapon))
+                return true;
+
+            if (target == CellType.WeaponOuter && (component == CellType.Outer || component == CellType.Weapon))
+                return true;
+            if (component == CellType.WeaponOuter && (target == CellType.Outer || target == CellType.Weapon))
+                return true;
+
+            if (target == CellType.All)
+                return true;
+
             return false;
 		}
 	}

--- a/Assets/Modules/ShipConstructor/Scripts/ShipLayoutObsolete.cs
+++ b/Assets/Modules/ShipConstructor/Scripts/ShipLayoutObsolete.cs
@@ -1,10 +1,10 @@
-using System; 
-using System.Linq;
-using System.Collections.Generic;
+using Constructor.Model;
 using GameDatabase.DataModel;
 using GameDatabase.Enums;
 using GameDatabase.Model;
-using Constructor.Model;
+using System; 
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Constructor
 {
@@ -178,7 +178,7 @@ namespace Constructor
 			if (element.ComponentId >= 0)
 				return false;
 			
-			if (element.Type == CellType.Weapon && component.CellType == CellType.Weapon)
+			if ((element.Type == CellType.Weapon || element.Type == CellType.All || element.Type == CellType.WeaponEngine || element.Type == CellType.WeaponInner || element.Type == CellType.WeaponOuter) && component.CellType == CellType.Weapon)
 				return string.IsNullOrEmpty(element.WeaponClass) || component.WeaponSlotType == default || element.WeaponClass.Contains(component.WeaponSlotType);
 			
 			return component.CellType.CompatibleWith(element.Type);
@@ -235,7 +235,7 @@ namespace Constructor
             var index = y * Size + x;
             var item = _layout[index];
 
-			if (item.Type != CellType.Weapon || item.BarrelId >= 0)
+			if ((item.Type != CellType.Weapon  && item.Type != CellType.All && item.Type != CellType.WeaponEngine && item.Type != CellType.WeaponInner && item.Type != CellType.WeaponOuter) || item.BarrelId >= 0)
 				return false;
 
             var dataChanged = false;
@@ -256,7 +256,7 @@ namespace Constructor
 
 		private static bool TryAssignBarrelId(ref LayoutElement item, LayoutElement other)
 		{
-			if (other.Type == CellType.Weapon && !other.IsCustomWeaponCell && other.BarrelId >= 0)
+			if ((other.Type == CellType.Weapon || other.Type == CellType.All || other.Type == CellType.WeaponInner || other.Type == CellType.WeaponOuter || other.Type == CellType.WeaponEngine) && !other.IsCustomWeaponCell && other.BarrelId >= 0)
 			{
 				item.BarrelId = other.BarrelId;
 				item.WeaponClass = other.WeaponClass;

--- a/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
+++ b/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
@@ -161,7 +161,7 @@ namespace Constructor.Ships.Modification
                 var t = (CellType)_stockLayout[x, y - 1];
                 var b = (CellType)_stockLayout[x, y + 1];
 
-                return value == l || value == r || value == t || value == b;
+                return value == l || value == r || value == t || value == b || l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All;
             }
 
             public bool TryModifyCell(int x, int y, CellType value)

--- a/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
+++ b/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
@@ -133,12 +133,21 @@ namespace Constructor.Ships.Modification
                         var t = (CellType)_stockLayout[x, y - 1];
                         var b = (CellType)_stockLayout[x, y + 1];
 
-                        if (l == CellType.Weapon || r == CellType.Weapon || t == CellType.Weapon || b == CellType.Weapon)
+                        if (l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All)
+                            _layout[index] = (char)CellType.Engine;
+                        else if (l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All)
+                            _layout[index] = (char)CellType.Inner;
+                        else if (l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All)
+                            _layout[index] = (char)CellType.Outer;
+
+                        else if (l == CellType.Weapon || r == CellType.Weapon || t == CellType.Weapon || b == CellType.Weapon)
                             _layout[index] = (char)Layout.CustomWeaponCell;
                         else if (l == CellType.Inner || r == CellType.Inner || t == CellType.Inner || b == CellType.Inner)
                             _layout[index] = (char)CellType.Inner;
                         else if (l == CellType.Engine || r == CellType.Engine || t == CellType.Engine || b == CellType.Engine)
                             _layout[index] = (char)CellType.Engine;
+                        
+
                         else
                             _layout[index] = (char)CellType.Outer;
                     }

--- a/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
+++ b/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
@@ -36,8 +36,8 @@ namespace Constructor.Ships.Modification
 
         public bool TryAddCell(int x, int y, CellType cellType)
         {
-			if (_customLayout == null || !_customLayout.TryModifyCell(x, y, cellType))
-				return false;
+            if (_customLayout == null || !_customLayout.TryModifyCell(x, y, cellType))
+                return false;
 
             DataChangedEvent?.Invoke();
 
@@ -51,7 +51,7 @@ namespace Constructor.Ships.Modification
 
         public int TotalExtraCells()
         {
-			return _customLayout == null ? 0 : _customLayout.CustomizableCellCount;
+            return _customLayout == null ? 0 : _customLayout.CustomizableCellCount;
         }
 
         public int ExtraCells()
@@ -83,16 +83,16 @@ namespace Constructor.Ships.Modification
 
         public IEnumerable<byte> Serialize()
         {
-			return _customLayout?.Serialize() ?? Enumerable.Empty<byte>();
+            return _customLayout?.Serialize() ?? Enumerable.Empty<byte>();
         }
 
-		public bool IsCellValid(int x, int y, CellType type)
-		{
-			return _customLayout != null && _customLayout.IsValidModification(x, y, type);
-		}
+        public bool IsCellValid(int x, int y, CellType type)
+        {
+            return _customLayout != null && _customLayout.IsValidModification(x, y, type);
+        }
 
-		private class CustomLayout : IShipLayout
-		{
+        private class CustomLayout : IShipLayout
+        {
             private readonly Layout _stockLayout;
             private readonly char[] _layout;
             private readonly LayoutRect _rect;
@@ -100,8 +100,8 @@ namespace Constructor.Ships.Modification
             private int _addedCellCount;
 
             public CustomLayout(Layout stockLayout)
-			{
-				_stockLayout = stockLayout;
+            {
+                _stockLayout = stockLayout;
                 var size = _stockLayout.Size;
                 var data = _stockLayout.Data;
 
@@ -109,15 +109,15 @@ namespace Constructor.Ships.Modification
                 for (int i = 0; i < size; ++i)
                 {
                     if (data[i] != (char)CellType.Empty) top = true;
-                    if (data[size*size - i - 1] != (char)CellType.Empty) bottom = true;
-                    if (data[i*size] != (char)CellType.Empty) left = true;
-                    if (data[(i+1)*size - 1] != (char)CellType.Empty) right = true;
+                    if (data[size * size - i - 1] != (char)CellType.Empty) bottom = true;
+                    if (data[i * size] != (char)CellType.Empty) left = true;
+                    if (data[(i + 1) * size - 1] != (char)CellType.Empty) right = true;
                 }
 
-                _rect = new LayoutRect(left ? -1 : 0, top ? -1 : 0, right ? size : size-1, bottom ? size : size-1);
-				_layout = new char[_rect.Square];
-				Reset();
-			}
+                _rect = new LayoutRect(left ? -1 : 0, top ? -1 : 0, right ? size : size - 1, bottom ? size : size - 1);
+                _layout = new char[_rect.Square];
+                Reset();
+            }
 
             public void FullyUpgrade()
             {
@@ -133,21 +133,12 @@ namespace Constructor.Ships.Modification
                         var t = (CellType)_stockLayout[x, y - 1];
                         var b = (CellType)_stockLayout[x, y + 1];
 
-                        if (l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All)
-                            _layout[index] = (char)CellType.Engine;
-                        else if (l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All)
-                            _layout[index] = (char)CellType.Inner;
-                        else if (l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All)
-                            _layout[index] = (char)CellType.Outer;
-
-                        else if (l == CellType.Weapon || r == CellType.Weapon || t == CellType.Weapon || b == CellType.Weapon)
+                        if (l == CellType.Weapon || r == CellType.Weapon || t == CellType.Weapon || b == CellType.Weapon)
                             _layout[index] = (char)Layout.CustomWeaponCell;
                         else if (l == CellType.Inner || r == CellType.Inner || t == CellType.Inner || b == CellType.Inner)
                             _layout[index] = (char)CellType.Inner;
                         else if (l == CellType.Engine || r == CellType.Engine || t == CellType.Engine || b == CellType.Engine)
                             _layout[index] = (char)CellType.Engine;
-                        
-
                         else
                             _layout[index] = (char)CellType.Outer;
                     }
@@ -155,47 +146,47 @@ namespace Constructor.Ships.Modification
             }
 
             public bool IsValidModification(int x, int y, CellType value)
-			{
-                if (!_rect.IsInsideRect(x,y))
+            {
+                if (!_rect.IsInsideRect(x, y))
                     return false;
 
                 if (!IsCustomizable(x, y))
                     return false;
 
-				if (value == CellType.Outer)
-					return true;
+                if (value == CellType.Outer)
+                    return true;
 
-				var l = (CellType)_stockLayout[x - 1, y];
-				var r = (CellType)_stockLayout[x + 1, y];
-				var t = (CellType)_stockLayout[x, y - 1];
-				var b = (CellType)_stockLayout[x, y + 1];
+                var l = (CellType)_stockLayout[x - 1, y];
+                var r = (CellType)_stockLayout[x + 1, y];
+                var t = (CellType)_stockLayout[x, y - 1];
+                var b = (CellType)_stockLayout[x, y + 1];
 
-				return value == l || value == r || value == t || value == b;
-			}
+                return value == l || value == r || value == t || value == b;
+            }
 
-			public bool TryModifyCell(int x, int y, CellType value)
-			{
-				if (!IsValidModification(x, y, value)) return false;
+            public bool TryModifyCell(int x, int y, CellType value)
+            {
+                if (!IsValidModification(x, y, value)) return false;
 
-				if (value == CellType.Weapon)
-					value = Layout.CustomWeaponCell;
+                if (value == CellType.Weapon)
+                    value = Layout.CustomWeaponCell;
 
-				_layout[_rect.ToArrayIndex(x, y)] = (char)value;
+                _layout[_rect.ToArrayIndex(x, y)] = (char)value;
                 _addedCellCount++;
-				return true;
-			}
+                return true;
+            }
 
-			public IEnumerable<byte> Serialize()
-			{
-				if (_addedCellCount == 0)
-					yield break;
+            public IEnumerable<byte> Serialize()
+            {
+                if (_addedCellCount == 0)
+                    yield break;
 
                 for (int i = _rect.yMin; i <= _rect.yMax; ++i)
                 {
                     for (int j = _rect.xMin; j <= _rect.xMax; ++j)
                     {
                         if (!IsCustomizable(j, i)) continue;
-                        yield return CellTypeConveter.ToByte((CellType)_layout[_rect.ToArrayIndex(j,i)]);
+                        yield return CellTypeConveter.ToByte((CellType)_layout[_rect.ToArrayIndex(j, i)]);
                     }
                 }
             }
@@ -227,69 +218,69 @@ namespace Constructor.Ships.Modification
             }
 
             public void DeserializeObsolete(byte[] data)
-			{
-				Reset();
+            {
+                Reset();
 
-				var index = 0;
-				var dataIndex = 0;
-				var size = _stockLayout.Size;
+                var index = 0;
+                var dataIndex = 0;
+                var size = _stockLayout.Size;
 
-				while (dataIndex < data.Length && index < _layout.Length)
-				{
-					if (data[dataIndex] == (byte)CellType.Empty)
-					{
-						dataIndex++;
-						index += data[dataIndex++];
-						continue;
-					}
+                while (dataIndex < data.Length && index < _layout.Length)
+                {
+                    if (data[dataIndex] == (byte)CellType.Empty)
+                    {
+                        dataIndex++;
+                        index += data[dataIndex++];
+                        continue;
+                    }
 
-					var x = index % size;
-					var y = index / size;
+                    var x = index % size;
+                    var y = index / size;
 
-					if (!TryModifyCell(x, y, (CellType)data[dataIndex]))
+                    if (!TryModifyCell(x, y, (CellType)data[dataIndex]))
                         UnityEngine.Debug.LogError($"Invalid modification [{x},{y}]");
 
-					index++;
-					dataIndex++;
-				}
-			}
+                    index++;
+                    dataIndex++;
+                }
+            }
 
-			public void Reset()
-			{
+            public void Reset()
+            {
                 _addedCellCount = 0;
                 _customizableCellCount = 0;
 
-				for (var i = _rect.yMin; i <= _rect.yMax; ++i)
-				{
-					for (var j = _rect.xMin; j <= _rect.xMax; ++j)
-					{
-						var x = j;
-						var y = i;
+                for (var i = _rect.yMin; i <= _rect.yMax; ++i)
+                {
+                    for (var j = _rect.xMin; j <= _rect.xMax; ++j)
+                    {
+                        var x = j;
+                        var y = i;
 
                         var index = _rect.ToArrayIndex(x, y);
                         var cellType = _stockLayout[x, y];
-						if (cellType != (char)CellType.Empty)
-						{
-							_layout[index] = cellType;
-						}
-						else if (_stockLayout[x, y - 1] != (char)CellType.Empty || _stockLayout[x - 1, y] != (char)CellType.Empty ||
-							_stockLayout[x + 1, y] != (char)CellType.Empty || _stockLayout[x, y + 1] != (char)CellType.Empty)
-						{
-							_layout[index] = (char)Layout.CustomizableCell;
+                        if (cellType != (char)CellType.Empty)
+                        {
+                            _layout[index] = cellType;
+                        }
+                        else if (_stockLayout[x, y - 1] != (char)CellType.Empty || _stockLayout[x - 1, y] != (char)CellType.Empty ||
+                            _stockLayout[x + 1, y] != (char)CellType.Empty || _stockLayout[x, y + 1] != (char)CellType.Empty)
+                        {
+                            _layout[index] = (char)Layout.CustomizableCell;
                             _customizableCellCount++;
-						}
-						else
-						{
-							_layout[index] = (char)CellType.Empty;
-						}
-					}
-				}
-			}
+                        }
+                        else
+                        {
+                            _layout[index] = (char)CellType.Empty;
+                        }
+                    }
+                }
+            }
 
             public int AddedCellCount => _addedCellCount;
             public int CustomizableCellCount => _customizableCellCount;
 
-            private bool IsCustomizable(int x, int y) => _stockLayout[x,y] == (char)CellType.Empty && _layout[_rect.ToArrayIndex(x,y)] != (char)CellType.Empty;
+            private bool IsCustomizable(int x, int y) => _stockLayout[x, y] == (char)CellType.Empty && _layout[_rect.ToArrayIndex(x, y)] != (char)CellType.Empty;
             public ref readonly LayoutRect Rect => ref _rect;
             public int CellCount => _stockLayout.CellCount + _addedCellCount;
             public int Size => _stockLayout.Size;
@@ -307,11 +298,17 @@ namespace Constructor.Ships.Modification
                 {
                     switch (cellType)
                     {
-                        case CellType.Outer: 
+                        case CellType.Outer:
+                        case CellType.InnerEngine:
+                        case CellType.OuterEngine:
+                        case CellType.WeaponEngine:
+                        case CellType.WeaponOuter:
+                        case CellType.WeaponInner:
                             return OuterCell;
-                        case CellType.Inner: 
+                        case CellType.Inner:
                             return InnerCell;
-                        case CellType.Engine: 
+                        case CellType.Engine:
+                        case CellType.All:
                             return EngineCell;
                         case CellType.Weapon:
                         case Layout.CustomWeaponCell:
@@ -350,5 +347,5 @@ namespace Constructor.Ships.Modification
                 }
             }
         }
-	}
+    }
 }

--- a/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
+++ b/Assets/Modules/ShipConstructor/Scripts/Ships/Modification/LayoutModifications.cs
@@ -161,6 +161,14 @@ namespace Constructor.Ships.Modification
                 var t = (CellType)_stockLayout[x, y - 1];
                 var b = (CellType)_stockLayout[x, y + 1];
 
+                // Optional logic that allows Engine/? and Weapon/? slots to be expanded to their respective first value (engine or weapon)
+                // Weapon/Engine slot can be expanded into Engine only (not including Outer).
+                // Doesn't affect any Green slot expansion logic.
+                if (value == CellType.Engine && (l == CellType.WeaponEngine || l == CellType.InnerEngine || l == CellType.OuterEngine || r == CellType.WeaponEngine || r == CellType.InnerEngine || r == CellType.OuterEngine || t == CellType.WeaponEngine || t == CellType.InnerEngine || t == CellType.OuterEngine || b == CellType.WeaponEngine || b == CellType.InnerEngine || b == CellType.OuterEngine))
+                    return true;
+                if (value == CellType.Weapon && (l == CellType.WeaponInner || l == CellType.WeaponOuter || r == CellType.WeaponInner || r == CellType.WeaponOuter || t == CellType.WeaponInner || t == CellType.WeaponOuter || b == CellType.WeaponInner || b == CellType.WeaponOuter))
+                    return true;
+
                 return value == l || value == r || value == t || value == b || l == CellType.All || r == CellType.All || t == CellType.All || b == CellType.All;
             }
 

--- a/Assets/Resources/Gui/StarMapScene/ShipyardWindow.prefab
+++ b/Assets/Resources/Gui/StarMapScene/ShipyardWindow.prefab
@@ -18485,11 +18485,11 @@ MonoBehaviour:
   OuterBlock: {fileID: 114884176730582308}
   EngineBlock: {fileID: 114249964346711904}
   IoBlock: {fileID: 114676432296711226}
-  OeBlock: {fileID: 5959242650295001509}
-  IeBlock: {fileID: 3164804152278795350}
-  WeBlock: {fileID: 405418894583297132}
-  WoBlock: {fileID: 7184667524974478809}
-  WiBlock: {fileID: 7855979295071858957}
+  OuterEngineBlock: {fileID: 5959242650295001509}
+  InnerEngineBlock: {fileID: 3164804152278795350}
+  WeaponEngineBlock: {fileID: 405418894583297132}
+  WeaponOuterBlock: {fileID: 7184667524974478809}
+  WeaponInnerBlock: {fileID: 7855979295071858957}
   AllBlock: {fileID: 8990421594967232111}
   CustomBlock: {fileID: 114735871356398318}
   Selection: {fileID: 114452224105346906}

--- a/Assets/Resources/Gui/StarMapScene/ShipyardWindow.prefab
+++ b/Assets/Resources/Gui/StarMapScene/ShipyardWindow.prefab
@@ -31,7 +31,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224334278854978192}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -112,7 +111,6 @@ RectTransform:
   m_Children:
   - {fileID: 224203544902294012}
   m_Father: {fileID: 224282143871744406}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -233,7 +231,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224494000816484568}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -310,7 +307,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -372,7 +368,6 @@ RectTransform:
   - {fileID: 224508638270485572}
   - {fileID: 224445044038887832}
   m_Father: {fileID: 224203544902294012}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -510,7 +505,6 @@ RectTransform:
   m_Children:
   - {fileID: 224297786920454884}
   m_Father: {fileID: 224731660145778398}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -608,7 +602,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224299556236167964}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -693,7 +686,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224985448828910584}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -791,7 +783,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224563592193295906}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -875,7 +866,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224443240284845224}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -957,7 +947,6 @@ RectTransform:
   - {fileID: 224446931473777534}
   - {fileID: 224569366804993906}
   m_Father: {fileID: 224430080117232890}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1081,7 +1070,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224836344597770880}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1169,7 +1157,6 @@ RectTransform:
   - {fileID: 224513790607516416}
   - {fileID: 224363149764038552}
   m_Father: {fileID: 224698562842809152}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1324,7 +1311,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224334278854978192}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1425,7 +1411,6 @@ RectTransform:
   - {fileID: 224447026139555486}
   - {fileID: 224947048357611950}
   m_Father: {fileID: 224569366804993906}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1511,7 +1496,6 @@ RectTransform:
   - {fileID: 224831029588565400}
   - {fileID: 224373854855455856}
   m_Father: {fileID: 224312417773882540}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1599,7 +1583,6 @@ RectTransform:
   - {fileID: 224258218683195528}
   - {fileID: 224077489014500720}
   m_Father: {fileID: 224299556236167964}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1754,7 +1737,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224825108647442074}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1848,7 +1830,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1947,7 +1928,6 @@ RectTransform:
   - {fileID: 224114829987190340}
   - {fileID: 224955090210094606}
   m_Father: {fileID: 224810165732844484}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2018,7 +1998,6 @@ RectTransform:
   - {fileID: 224421576298895928}
   - {fileID: 224312417773882540}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2078,6 +2057,7 @@ MonoBehaviour:
   _class: 1
   _waitOpenAnimationDone: 0
   _waitCloseAnimationDone: 0
+  _initiallyHidden: 0
   _escapeKeyAction: 2
   OnInitializedEvent:
     m_PersistentCalls:
@@ -2226,7 +2206,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224944679161657144}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2314,7 +2293,6 @@ RectTransform:
   - {fileID: 224710259158715938}
   - {fileID: 224863972230008732}
   m_Father: {fileID: 224402104973876682}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2440,7 +2418,6 @@ RectTransform:
   - {fileID: 224560517076675116}
   - {fileID: 224946199891326598}
   m_Father: {fileID: 224004156373614602}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2506,7 +2483,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224562822629741580}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2585,7 +2561,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224642056285704610}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2686,7 +2661,6 @@ RectTransform:
   - {fileID: 224398094515848302}
   - {fileID: 224877527028481720}
   m_Father: {fileID: 224699214117727220}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2750,7 +2724,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224310835035031358}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2836,7 +2809,6 @@ RectTransform:
   m_Children:
   - {fileID: 224710997984776050}
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2933,7 +2905,6 @@ RectTransform:
   - {fileID: 224944638375570680}
   - {fileID: 224764288516778908}
   m_Father: {fileID: 224698562842809152}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3087,7 +3058,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224492570476293146}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3171,7 +3141,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224323930006071828}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3253,7 +3222,6 @@ RectTransform:
   - {fileID: 224207796690955420}
   - {fileID: 224801067830589566}
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3408,7 +3376,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3507,7 +3474,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224299556236167964}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3592,7 +3558,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224985448828910584}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3691,7 +3656,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3789,7 +3753,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224508638270485572}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3873,7 +3836,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224221151048302624}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3962,7 +3924,6 @@ RectTransform:
   - {fileID: 224430080117232890}
   - {fileID: 224402104973876682}
   m_Father: {fileID: 224837686208612692}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4087,7 +4048,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224211560181987228}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4187,7 +4147,6 @@ RectTransform:
   m_Children:
   - {fileID: 224117535897981700}
   m_Father: {fileID: 224304950285210322}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4285,7 +4244,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224560517076675116}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4367,7 +4325,6 @@ RectTransform:
   - {fileID: 224056821545041788}
   - {fileID: 224037988923354166}
   m_Father: {fileID: 224698562842809152}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4522,7 +4479,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224218656483653388}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4619,7 +4575,6 @@ RectTransform:
   m_Children:
   - {fileID: 224264239752888866}
   m_Father: {fileID: 224906406380938182}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4658,7 +4613,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224944679161657144}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4756,7 +4710,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224985448828910584}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4841,7 +4794,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224186504118838024}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4940,7 +4892,6 @@ RectTransform:
   m_Children:
   - {fileID: 224323882343938102}
   m_Father: {fileID: 224563966985225400}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5009,7 +4960,6 @@ RectTransform:
   - {fileID: 224343384918550954}
   - {fileID: 224551718753876376}
   m_Father: {fileID: 224402104973876682}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5107,7 +5057,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224764645641048482}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5191,7 +5140,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224604515030163616}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5279,7 +5227,6 @@ RectTransform:
   - {fileID: 224299556236167964}
   - {fileID: 224282143871744406}
   m_Father: {fileID: 224398094515848302}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5410,7 +5357,6 @@ RectTransform:
   - {fileID: 224346880430382884}
   - {fileID: 224105630966728036}
   m_Father: {fileID: 224073261057283198}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5620,7 +5566,6 @@ RectTransform:
   - {fileID: 224641827406242536}
   - {fileID: 224380398509987866}
   m_Father: {fileID: 224073261057283198}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5823,7 +5768,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224244852115489312}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5902,7 +5846,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224723797804685618}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6002,7 +5945,6 @@ RectTransform:
   - {fileID: 224310835035031358}
   - {fileID: 224420810753401148}
   m_Father: {fileID: 224577851519899822}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6087,7 +6029,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224810165732844484}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6172,7 +6113,6 @@ RectTransform:
   m_Children:
   - {fileID: 224353592658117866}
   m_Father: {fileID: 224312417773882540}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6257,7 +6197,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224109590139328504}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6356,7 +6295,6 @@ RectTransform:
   - {fileID: 224452258576676022}
   - {fileID: 224994346104906596}
   m_Father: {fileID: 224503638982166104}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6531,7 +6469,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6590,7 +6527,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224205111899852858}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6688,7 +6624,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224215213290843604}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6770,7 +6705,6 @@ RectTransform:
   - {fileID: 224179471863582596}
   - {fileID: 224280838816570458}
   m_Father: {fileID: 224698562842809152}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6924,7 +6858,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -7008,7 +6941,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224722270511768476}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -7092,7 +7024,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224989958532428586}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7172,7 +7103,6 @@ RectTransform:
   - {fileID: 224191758782835956}
   - {fileID: 224762305257069230}
   m_Father: {fileID: 224450665480144922}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7258,7 +7188,6 @@ RectTransform:
   m_Children:
   - {fileID: 224989958532428586}
   m_Father: {fileID: 224282143871744406}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7378,7 +7307,6 @@ RectTransform:
   - {fileID: 224073261057283198}
   - {fileID: 224899879691602708}
   m_Father: {fileID: 224577851519899822}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7504,7 +7432,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224507316060082962}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -7608,7 +7535,6 @@ RectTransform:
   - {fileID: 224878348347435902}
   - {fileID: 224944679161657144}
   m_Father: {fileID: 224562894534321848}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -7732,7 +7658,6 @@ RectTransform:
   m_Children:
   - {fileID: 224410649636722602}
   m_Father: {fileID: 224450665480144922}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7833,7 +7758,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224932925514873592}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -7918,7 +7842,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8017,7 +7940,6 @@ RectTransform:
   - {fileID: 224375785948459352}
   - {fileID: 224273678622067886}
   m_Father: {fileID: 224503638982166104}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8193,7 +8115,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224722270511768476}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8276,7 +8197,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224205111899852858}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8335,7 +8255,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224891167548838790}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8434,7 +8353,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224562822629741580}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -8516,7 +8434,6 @@ RectTransform:
   - {fileID: 224465329784486444}
   - {fileID: 224731660145778398}
   m_Father: {fileID: 224786901534183380}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8649,7 +8566,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224205111899852858}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8747,7 +8663,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224305602843090064}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8833,7 +8748,6 @@ RectTransform:
   - {fileID: 224604515030163616}
   - {fileID: 224244852115489312}
   m_Father: {fileID: 224699214117727220}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8909,7 +8823,6 @@ RectTransform:
   - {fileID: 224599604297824014}
   - {fileID: 224218656483653388}
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -8987,7 +8900,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224698562842809152}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9085,7 +8997,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224305602843090064}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -9164,7 +9075,6 @@ RectTransform:
   - {fileID: 224654364706169744}
   - {fileID: 224826328496472164}
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9229,7 +9139,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224831029588565400}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9323,7 +9232,6 @@ RectTransform:
   - {fileID: 224814201660636166}
   - {fileID: 224049491306038596}
   m_Father: {fileID: 224170963658163162}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9387,7 +9295,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224715465542654480}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9466,7 +9373,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224443240284845224}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9566,7 +9472,6 @@ RectTransform:
   - {fileID: 224900550844451132}
   - {fileID: 224450665480144922}
   m_Father: {fileID: 224434667871290524}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9650,7 +9555,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224001434319431432}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9737,7 +9641,6 @@ RectTransform:
   - {fileID: 224707429938822020}
   - {fileID: 224394360205101798}
   m_Father: {fileID: 224863972230008732}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9818,7 +9721,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224221151048302624}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9895,7 +9797,6 @@ RectTransform:
   m_Children:
   - {fileID: 224263367428481714}
   m_Father: {fileID: 224946199891326598}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9934,7 +9835,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224001434319431432}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10037,7 +9937,6 @@ RectTransform:
   - {fileID: 224786901534183380}
   - {fileID: 224906406380938182}
   m_Father: {fileID: 224577851519899822}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -10191,7 +10090,6 @@ RectTransform:
   - {fileID: 224519796789345656}
   - {fileID: 224891328539669202}
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10257,7 +10155,6 @@ RectTransform:
   m_Children:
   - {fileID: 224134164403150910}
   m_Father: {fileID: 224304950285210322}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10355,7 +10252,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224932925514873592}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10440,7 +10336,6 @@ RectTransform:
   - {fileID: 224370978294456142}
   - {fileID: 224395443851055022}
   m_Father: {fileID: 224340346698603042}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10505,7 +10400,6 @@ RectTransform:
   m_Children:
   - {fileID: 224507144224483066}
   m_Father: {fileID: 224577851519899822}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -10597,7 +10491,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224974335290454232}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -10695,7 +10588,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224696788302157560}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10780,7 +10672,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224601070632082514}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
@@ -10873,7 +10764,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224696788302157560}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10974,7 +10864,6 @@ RectTransform:
   m_Children:
   - {fileID: 224498078052714312}
   m_Father: {fileID: 224175815928337004}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -11080,7 +10969,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224731660145778398}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -11184,7 +11072,6 @@ RectTransform:
   - {fileID: 224170963658163162}
   - {fileID: 224415542875203774}
   m_Father: {fileID: 224498078052714312}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -11346,7 +11233,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224205111899852858}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -11448,7 +11334,6 @@ RectTransform:
   - {fileID: 224215213290843604}
   - {fileID: 224562822629741580}
   m_Father: {fileID: 224730530884825594}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -11546,7 +11431,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224974335290454232}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -11641,7 +11525,6 @@ RectTransform:
   m_Children:
   - {fileID: 224012264282090314}
   m_Father: {fileID: 224175815928337004}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
@@ -11758,7 +11641,6 @@ RectTransform:
   m_Children:
   - {fileID: 224718553293341868}
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -11851,7 +11733,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224244852115489312}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -11931,7 +11812,6 @@ RectTransform:
   m_Children:
   - {fileID: 224354268751958296}
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -12023,7 +11903,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -12081,7 +11960,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224900550844451132}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -12158,7 +12036,6 @@ RectTransform:
   m_Children:
   - {fileID: 224972797257276336}
   m_Father: {fileID: 224288244405543460}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -12196,7 +12073,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224031761419976896}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -12282,7 +12158,6 @@ RectTransform:
   - {fileID: 224651775437521178}
   - {fileID: 224183223659545058}
   m_Father: {fileID: 224251636448457600}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -12373,7 +12248,6 @@ RectTransform:
   - {fileID: 224509392821613434}
   - {fileID: 224387550236296380}
   m_Father: {fileID: 224073261057283198}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -12577,7 +12451,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224642056285704610}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -12680,7 +12553,6 @@ RectTransform:
   - {fileID: 224764645641048482}
   - {fileID: 224723797804685618}
   m_Father: {fileID: 224299556236167964}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -12795,7 +12667,6 @@ RectTransform:
   - {fileID: 224211560181987228}
   - {fileID: 224891167548838790}
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -12914,7 +12785,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -12975,7 +12845,6 @@ RectTransform:
   - {fileID: 224279939930366954}
   - {fileID: 224099146079259304}
   m_Father: {fileID: 224420810753401148}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -13116,7 +12985,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224186504118838024}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -13218,7 +13086,6 @@ RectTransform:
   m_Children:
   - {fileID: 224427620004743080}
   m_Father: {fileID: 224353592658117866}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -13357,7 +13224,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224599604297824014}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -13456,7 +13322,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224764645641048482}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -13554,7 +13419,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224170963658163162}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -13639,7 +13503,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224218656483653388}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -13742,7 +13605,6 @@ RectTransform:
   - {fileID: 224932925514873592}
   - {fileID: 224304950285210322}
   m_Father: {fileID: 224731660145778398}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -13847,7 +13709,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -13947,7 +13808,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224310835035031358}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -14059,7 +13919,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224562894534321848}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -14158,7 +14017,6 @@ RectTransform:
   m_Children:
   - {fileID: 224562894534321848}
   m_Father: {fileID: 224148676285061664}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -14235,7 +14093,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224498078052714312}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -14288,7 +14145,6 @@ RectTransform:
   m_Children:
   - {fileID: 224551939581173326}
   m_Father: {fileID: 224830852193768412}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -14383,7 +14239,6 @@ RectTransform:
   - {fileID: 224305602843090064}
   - {fileID: 224340346698603042}
   m_Father: {fileID: 224618847422230944}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -14478,7 +14333,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224218656483653388}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -14556,7 +14410,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224682068515221478}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -14636,7 +14489,6 @@ RectTransform:
   m_Children:
   - {fileID: 224239628077301170}
   m_Father: {fileID: 224304950285210322}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -14735,7 +14587,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -14828,7 +14679,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224768240958100514}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -14907,7 +14757,6 @@ RectTransform:
   - {fileID: 224004156373614602}
   - {fileID: 224563966985225400}
   m_Father: {fileID: 224420810753401148}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -14971,7 +14820,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224801504331299390}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -15051,7 +14899,6 @@ RectTransform:
   m_Children:
   - {fileID: 224702483016450266}
   m_Father: {fileID: 224638160429194194}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -15142,7 +14989,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224211560181987228}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -15222,7 +15068,6 @@ RectTransform:
   m_Children:
   - {fileID: 224278406739371732}
   m_Father: {fileID: 224562894534321848}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -15321,7 +15166,6 @@ RectTransform:
   m_Children:
   - {fileID: 224843144172482834}
   m_Father: {fileID: 224004156373614602}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -15391,7 +15235,6 @@ RectTransform:
   - {fileID: 224434667871290524}
   - {fileID: 224573180548416562}
   m_Father: {fileID: 224324729657833286}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -15518,7 +15361,6 @@ RectTransform:
   - {fileID: 224537506938315528}
   - {fileID: 224785762511189428}
   m_Father: {fileID: 224730530884825594}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -15617,7 +15459,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224599604297824014}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -15717,7 +15558,6 @@ RectTransform:
   - {fileID: 224323930006071828}
   - {fileID: 224251636448457600}
   m_Father: {fileID: 224434667871290524}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -15801,7 +15641,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224723797804685618}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -15886,7 +15725,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224031761419976896}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -15986,7 +15824,6 @@ RectTransform:
   - {fileID: 224221151048302624}
   - {fileID: 224971869160847196}
   m_Father: {fileID: 224563966985225400}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -16052,7 +15889,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224682068515221478}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -16133,7 +15969,6 @@ RectTransform:
   - {fileID: 224908442853877982}
   - {fileID: 224201948690682888}
   m_Father: {fileID: 224430080117232890}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -16231,7 +16066,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224959419234195502}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -16311,7 +16145,6 @@ RectTransform:
   - {fileID: 224148676285061664}
   - {fileID: 224288244405543460}
   m_Father: {fileID: 224618847422230944}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -16383,7 +16216,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224730530884825594}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -16468,7 +16300,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224410649636722602}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
@@ -16561,7 +16392,6 @@ RectTransform:
   - {fileID: 224205580888343306}
   - {fileID: 224532220922040856}
   m_Father: {fileID: 224340346698603042}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -16626,7 +16456,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -16726,7 +16555,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224443240284845224}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -16825,7 +16653,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224831029588565400}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -16926,7 +16753,6 @@ RectTransform:
   - {fileID: 224775252730506682}
   - {fileID: 224857822832494558}
   m_Father: {fileID: 224573180548416562}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -17024,7 +16850,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224754745417185724}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -17105,7 +16930,6 @@ RectTransform:
   m_Children:
   - {fileID: 224830852193768412}
   m_Father: {fileID: 224877527028481720}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -17230,7 +17054,6 @@ RectTransform:
   - {fileID: 224930486212903522}
   - {fileID: 224880555708223310}
   m_Father: {fileID: 224340346698603042}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -17294,7 +17117,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224836344597770880}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -17379,7 +17201,6 @@ RectTransform:
   - {fileID: 224838541280582392}
   - {fileID: 224492570476293146}
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -17443,7 +17264,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224186504118838024}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -17529,7 +17349,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224279939930366954}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -17653,7 +17472,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224005011783406636}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -17732,7 +17550,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224825108647442074}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -17836,7 +17653,6 @@ RectTransform:
   - {fileID: 224288682213200378}
   - {fileID: 224562677152871356}
   m_Father: {fileID: 224503638982166104}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18015,7 +17831,6 @@ RectTransform:
   - {fileID: 224324729657833286}
   - {fileID: 224730530884825594}
   m_Father: {fileID: 224312417773882540}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18073,7 +17888,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224562822629741580}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -18151,7 +17965,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224215213290843604}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -18233,7 +18046,6 @@ RectTransform:
   - {fileID: 224768240958100514}
   - {fileID: 224959419234195502}
   m_Father: {fileID: 224170963658163162}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18338,7 +18150,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224944679161657144}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -18442,7 +18253,6 @@ RectTransform:
   - {fileID: 224379700421258110}
   - {fileID: 224470124104129208}
   m_Father: {fileID: 224503638982166104}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18620,13 +18430,18 @@ RectTransform:
   - {fileID: 224518143969744384}
   - {fileID: 224563592193295906}
   - {fileID: 224391563174781020}
+  - {fileID: 4713607704706586904}
   - {fileID: 224681611519079182}
   - {fileID: 224030885895287730}
   - {fileID: 224754745417185724}
+  - {fileID: 876932926831631926}
+  - {fileID: 900253037095737764}
+  - {fileID: 4676172693096051395}
+  - {fileID: 3685124062164062466}
+  - {fileID: 3106252567017004744}
   - {fileID: 224005011783406636}
   - {fileID: 224617983006188462}
   m_Father: {fileID: 224427620004743080}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18668,8 +18483,14 @@ MonoBehaviour:
   WeaponBlock: {fileID: 114087218902006914}
   InnerBlock: {fileID: 114389086733393830}
   OuterBlock: {fileID: 114884176730582308}
-  IoBlock: {fileID: 114676432296711226}
   EngineBlock: {fileID: 114249964346711904}
+  IoBlock: {fileID: 114676432296711226}
+  OeBlock: {fileID: 5959242650295001509}
+  IeBlock: {fileID: 3164804152278795350}
+  WeBlock: {fileID: 405418894583297132}
+  WoBlock: {fileID: 7184667524974478809}
+  WiBlock: {fileID: 7855979295071858957}
+  AllBlock: {fileID: 8990421594967232111}
   CustomBlock: {fileID: 114735871356398318}
   Selection: {fileID: 114452224105346906}
   BackgroundImage: {fileID: 114150759968945744}
@@ -18722,7 +18543,6 @@ RectTransform:
   - {fileID: 224094882734250836}
   - {fileID: 224069776024158796}
   m_Father: {fileID: 224310835035031358}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18800,7 +18620,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224492570476293146}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18885,7 +18704,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -18979,7 +18797,6 @@ RectTransform:
   - {fileID: 224886790555310698}
   - {fileID: 224940026801328186}
   m_Father: {fileID: 224170963658163162}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -19048,7 +18865,6 @@ RectTransform:
   - {fileID: 224349215843018474}
   - {fileID: 224722270511768476}
   m_Father: {fileID: 224324729657833286}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -19172,7 +18988,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224599604297824014}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -19250,7 +19065,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224560517076675116}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -19329,7 +19143,6 @@ RectTransform:
   - {fileID: 224504648338478466}
   - {fileID: 224014483690306820}
   m_Father: {fileID: 224421576298895928}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -19398,7 +19211,6 @@ RectTransform:
   - {fileID: 224281152795115802}
   - {fileID: 224666574015782524}
   m_Father: {fileID: 224569366804993906}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -19479,7 +19291,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224215213290843604}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -19558,7 +19369,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224109590139328504}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -19657,7 +19467,6 @@ RectTransform:
   m_Children:
   - {fileID: 224618847422230944}
   m_Father: {fileID: 224312417773882540}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -19741,7 +19550,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224682068515221478}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -19818,7 +19626,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224299556236167964}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -19876,7 +19683,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224012264282090314}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -19955,7 +19761,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224494000816484568}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -20046,7 +19851,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224205111899852858}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -20130,7 +19934,6 @@ RectTransform:
   m_Children:
   - {fileID: 224601070632082514}
   m_Father: {fileID: 224251636448457600}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -20232,7 +20035,6 @@ RectTransform:
   - {fileID: 224985448828910584}
   - {fileID: 224205111899852858}
   m_Father: {fileID: 224507316060082962}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -20297,7 +20099,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224604515030163616}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -20394,7 +20195,6 @@ RectTransform:
   m_Children:
   - {fileID: 224373572803218764}
   m_Father: {fileID: 224971869160847196}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -20432,7 +20232,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224279939930366954}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -20511,7 +20310,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224573180548416562}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -20611,7 +20409,6 @@ RectTransform:
   - {fileID: 224334278854978192}
   - {fileID: 224507316060082962}
   m_Father: {fileID: 224507144224483066}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -20732,7 +20529,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224551939581173326}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -20825,7 +20621,6 @@ RectTransform:
   m_Children:
   - {fileID: 224186504118838024}
   m_Father: {fileID: 224891167548838790}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -20889,7 +20684,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224297786920454884}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -20967,7 +20761,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224642056285704610}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -21048,7 +20841,6 @@ RectTransform:
   - {fileID: 224884150671323366}
   - {fileID: 224469570489317110}
   m_Father: {fileID: 224508638270485572}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -21128,7 +20920,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 224508638270485572}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -21155,3 +20946,1203 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: 1
   m_LayoutPriority: 1
+--- !u!1 &6929777689174737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4676172693096051395}
+  - component: {fileID: 4357126050945740283}
+  - component: {fileID: 317456939354105346}
+  - component: {fileID: 405418894583297132}
+  m_Layer: 5
+  m_Name: Block9
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4676172693096051395
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6929777689174737}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7916785491678885558}
+  - {fileID: 848065223810388887}
+  m_Father: {fileID: 224551939581173326}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 256, y: -0.000061035156}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4357126050945740283
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6929777689174737}
+  m_CullTransparentMesh: 0
+--- !u!114 &317456939354105346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6929777689174737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!114 &405418894583297132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6929777689174737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd0b85061a18ff0479663ed4fb7a9785, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Label: {fileID: 679039703678930322}
+  Background: {fileID: 0}
+  RectTransform: {fileID: 4676172693096051395}
+--- !u!1 &453921713534252064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5598555592178310578}
+  - component: {fileID: 7783465574378012583}
+  - component: {fileID: 6278714319640498995}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5598555592178310578
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453921713534252064}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 900253037095737764}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7783465574378012583
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453921713534252064}
+  m_CullTransparentMesh: 0
+--- !u!114 &6278714319640498995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453921713534252064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5019608, g: 1, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!1 &642440804612690206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3106252567017004744}
+  - component: {fileID: 6648536552749780339}
+  - component: {fileID: 1744697663938032472}
+  - component: {fileID: 7855979295071858957}
+  m_Layer: 5
+  m_Name: Block11
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3106252567017004744
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642440804612690206}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9214505476666357121}
+  - {fileID: 2482121574134103832}
+  m_Father: {fileID: 224551939581173326}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 256, y: -0.000061035156}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &6648536552749780339
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642440804612690206}
+  m_CullTransparentMesh: 0
+--- !u!114 &1744697663938032472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642440804612690206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5019608, g: 1, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!114 &7855979295071858957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642440804612690206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd0b85061a18ff0479663ed4fb7a9785, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Label: {fileID: 2276382288273557812}
+  Background: {fileID: 0}
+  RectTransform: {fileID: 3106252567017004744}
+--- !u!1 &965327599394255769
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 876932926831631926}
+  - component: {fileID: 7647842432310473802}
+  - component: {fileID: 4869524410017412556}
+  - component: {fileID: 5959242650295001509}
+  m_Layer: 5
+  m_Name: Block7
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &876932926831631926
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 965327599394255769}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3125567730024130}
+  m_Father: {fileID: 224551939581173326}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 256, y: -0.000061035156}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &7647842432310473802
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 965327599394255769}
+  m_CullTransparentMesh: 0
+--- !u!114 &4869524410017412556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 965327599394255769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!114 &5959242650295001509
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 965327599394255769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd0b85061a18ff0479663ed4fb7a9785, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Label: {fileID: 0}
+  Background: {fileID: 0}
+  RectTransform: {fileID: 876932926831631926}
+--- !u!1 &1617470200124145540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3125567730024130}
+  - component: {fileID: 8644420795445028428}
+  - component: {fileID: 686377494623935917}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3125567730024130
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617470200124145540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 876932926831631926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8644420795445028428
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617470200124145540}
+  m_CullTransparentMesh: 0
+--- !u!114 &686377494623935917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617470200124145540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5019608, g: 1, b: 1, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!1 &1632643364514687900
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7916785491678885558}
+  - component: {fileID: 7387015254236029819}
+  - component: {fileID: 5688502423210526846}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7916785491678885558
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1632643364514687900}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4676172693096051395}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7387015254236029819
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1632643364514687900}
+  m_CullTransparentMesh: 0
+--- !u!114 &5688502423210526846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1632643364514687900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.627451, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!1 &5096693063190400240
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6825932701925432599}
+  - component: {fileID: 1757366173144410633}
+  - component: {fileID: 3500123113208059917}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6825932701925432599
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5096693063190400240}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3685124062164062466}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -256, y: 0.00012207031}
+  m_SizeDelta: {x: -8, y: -8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1757366173144410633
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5096693063190400240}
+  m_CullTransparentMesh: 0
+--- !u!114 &3500123113208059917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5096693063190400240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a57811ade5f43264f96354d7400cca71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 0.5019608, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0331ea93716811747acff9f890a054ac, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 32
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: C
+  _themeColor: 0
+  _colorMode: 0
+  _themeFont: 0
+  _themeFontSize: 0
+--- !u!1 &5171798325071214167
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2482121574134103832}
+  - component: {fileID: 6011390488470752568}
+  - component: {fileID: 2276382288273557812}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2482121574134103832
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5171798325071214167}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3106252567017004744}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -256, y: 0.00012207031}
+  m_SizeDelta: {x: -8, y: -8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6011390488470752568
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5171798325071214167}
+  m_CullTransparentMesh: 0
+--- !u!114 &2276382288273557812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5171798325071214167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a57811ade5f43264f96354d7400cca71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 0.5019608, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0331ea93716811747acff9f890a054ac, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 32
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: C
+  _themeColor: 0
+  _colorMode: 0
+  _themeFont: 0
+  _themeFontSize: 0
+--- !u!1 &5873993553564498375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 900253037095737764}
+  - component: {fileID: 6993854516439977735}
+  - component: {fileID: 5841442611926255972}
+  - component: {fileID: 3164804152278795350}
+  m_Layer: 5
+  m_Name: Block8
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &900253037095737764
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5873993553564498375}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5598555592178310578}
+  m_Father: {fileID: 224551939581173326}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 256, y: -0.000061035156}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &6993854516439977735
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5873993553564498375}
+  m_CullTransparentMesh: 0
+--- !u!114 &5841442611926255972
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5873993553564498375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!114 &3164804152278795350
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5873993553564498375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd0b85061a18ff0479663ed4fb7a9785, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Label: {fileID: 0}
+  Background: {fileID: 0}
+  RectTransform: {fileID: 900253037095737764}
+--- !u!1 &5888656458503224128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 848065223810388887}
+  - component: {fileID: 9193787759434841864}
+  - component: {fileID: 679039703678930322}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &848065223810388887
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5888656458503224128}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4676172693096051395}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -256, y: 0.00012207031}
+  m_SizeDelta: {x: -8, y: -8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9193787759434841864
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5888656458503224128}
+  m_CullTransparentMesh: 0
+--- !u!114 &679039703678930322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5888656458503224128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a57811ade5f43264f96354d7400cca71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 0.5019608, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0331ea93716811747acff9f890a054ac, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 32
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: C
+  _themeColor: 0
+  _colorMode: 0
+  _themeFont: 0
+  _themeFontSize: 0
+--- !u!1 &6442237604243494128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3685124062164062466}
+  - component: {fileID: 3812947926832128713}
+  - component: {fileID: 1681189502712171419}
+  - component: {fileID: 7184667524974478809}
+  m_Layer: 5
+  m_Name: Block10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3685124062164062466
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6442237604243494128}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 727899853116146904}
+  - {fileID: 6825932701925432599}
+  m_Father: {fileID: 224551939581173326}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 256, y: -0.000061035156}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &3812947926832128713
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6442237604243494128}
+  m_CullTransparentMesh: 0
+--- !u!114 &1681189502712171419
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6442237604243494128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5019608, g: 1, b: 1, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!114 &7184667524974478809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6442237604243494128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd0b85061a18ff0479663ed4fb7a9785, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Label: {fileID: 3500123113208059917}
+  Background: {fileID: 0}
+  RectTransform: {fileID: 3685124062164062466}
+--- !u!1 &7368942179213337213
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9214505476666357121}
+  - component: {fileID: 7944375722799129759}
+  - component: {fileID: 850849050849051825}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9214505476666357121
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7368942179213337213}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3106252567017004744}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7944375722799129759
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7368942179213337213}
+  m_CullTransparentMesh: 0
+--- !u!114 &850849050849051825
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7368942179213337213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.627451, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!1 &7411479094249177318
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4713607704706586904}
+  - component: {fileID: 6996863985135703436}
+  - component: {fileID: 2778353191294050321}
+  - component: {fileID: 8990421594967232111}
+  m_Layer: 5
+  m_Name: Block12
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4713607704706586904
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7411479094249177318}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 224551939581173326}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 64, y: 0.000015258789}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &6996863985135703436
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7411479094249177318}
+  m_CullTransparentMesh: 0
+--- !u!114 &2778353191294050321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7411479094249177318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.52156866, g: 0.52156866, b: 0.52156866, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0
+--- !u!114 &8990421594967232111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7411479094249177318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd0b85061a18ff0479663ed4fb7a9785, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Label: {fileID: 0}
+  Background: {fileID: 0}
+  RectTransform: {fileID: 4713607704706586904}
+--- !u!1 &8557339156436242767
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 727899853116146904}
+  - component: {fileID: 2954859812460207902}
+  - component: {fileID: 5777222447056495917}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &727899853116146904
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8557339156436242767}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3685124062164062466}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2954859812460207902
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8557339156436242767}
+  m_CullTransparentMesh: 0
+--- !u!114 &5777222447056495917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8557339156436242767}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111079df60566940a316b73ad641512, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.627451, b: 0.5019608, a: 0.7058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad0e46f4346fe1d469766a6a5a059d52, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 2
+  m_FillAmount: 0.5
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  _themeColor: 0
+  _colorMode: 0

--- a/Assets/Scripts/Gui/ShipService/ShipLayoutPanel.cs
+++ b/Assets/Scripts/Gui/ShipService/ShipLayoutPanel.cs
@@ -20,8 +20,13 @@ namespace Gui.ShipService
         public BlockViewModel WeaponBlock;
         public BlockViewModel InnerBlock;
         public BlockViewModel OuterBlock;
-        public BlockViewModel IoBlock;
         public BlockViewModel EngineBlock;
+
+        public BlockViewModel IoBlock;
+
+        public BlockViewModel OeBlock;
+        public BlockViewModel IeBlock;
+
         public BlockViewModel CustomBlock;
         public BlockViewModel Selection;
         public Image BackgroundImage;
@@ -81,7 +86,12 @@ namespace Gui.ShipService
             WeaponBlock.gameObject.SetActive(false);
             InnerBlock.gameObject.SetActive(false);
             OuterBlock.gameObject.SetActive(false);
+            
             IoBlock.gameObject.SetActive(false);
+            
+            OeBlock.gameObject.SetActive(false);
+            IeBlock.gameObject.SetActive(false);
+            
             EngineBlock.gameObject.SetActive(false);
             CustomBlock.gameObject.SetActive(false);
             Cleanup();
@@ -122,16 +132,31 @@ namespace Gui.ShipService
                     return GameObject.Instantiate<BlockViewModel>(OuterBlock);
                 case CellType.Inner:
                     return GameObject.Instantiate<BlockViewModel>(InnerBlock);
-                case CellType.InnerOuter:
-                    return GameObject.Instantiate<BlockViewModel>(IoBlock);
 				case CellType.Weapon:
-				case Layout.CustomWeaponCell:
+				case CellType.WeaponEngine:
+				case CellType.WeaponInner:
+				case CellType.WeaponOuter:
+                case CellType.All:
+                case Layout.CustomWeaponCell:
 					var item = GameObject.Instantiate<BlockViewModel>(WeaponBlock);
 					//item.Label.text = string.IsNullOrEmpty(cell.WeaponClass) ? "•" : cell.WeaponClass;
 					return item;
 				case CellType.Engine:
                     return GameObject.Instantiate<BlockViewModel>(EngineBlock);
-				case Layout.CustomizableCell:
+
+                case CellType.OuterEngine:
+                    return GameObject.Instantiate<BlockViewModel>(OeBlock);
+
+                case CellType.InnerOuter:
+                    return GameObject.Instantiate<BlockViewModel>(IoBlock);
+
+                case CellType.InnerEngine:
+                    return GameObject.Instantiate<BlockViewModel>(IeBlock);
+
+                
+
+
+                case Layout.CustomizableCell:
 					return GameObject.Instantiate<BlockViewModel>(CustomBlock);
 			}
 
@@ -156,7 +181,12 @@ namespace Gui.ShipService
                     child == InnerBlock.transform ||
                     child == OuterBlock.transform ||
                     child == EngineBlock.transform ||
+
                     child == IoBlock.transform ||
+
+                    child == OeBlock.transform ||
+                    child == IeBlock.transform ||
+
                     child == CustomBlock.transform ||
                     child == Selection.transform ||
                     child == BackgroundImage.transform)

--- a/Assets/Scripts/Gui/ShipService/ShipLayoutPanel.cs
+++ b/Assets/Scripts/Gui/ShipService/ShipLayoutPanel.cs
@@ -27,6 +27,12 @@ namespace Gui.ShipService
         public BlockViewModel OeBlock;
         public BlockViewModel IeBlock;
 
+        public BlockViewModel WeBlock;
+        public BlockViewModel WoBlock;
+        public BlockViewModel WiBlock;
+
+        public BlockViewModel AllBlock;
+
         public BlockViewModel CustomBlock;
         public BlockViewModel Selection;
         public Image BackgroundImage;
@@ -37,7 +43,7 @@ namespace Gui.ShipService
         [SerializeField] public BlockSelectedEvent _onBlockSelected = new BlockSelectedEvent();
 
         [Serializable]
-        public class BlockSelectedEvent : UnityEvent<int,int> { };
+        public class BlockSelectedEvent : UnityEvent<int, int> { };
 
         public void Reset()
         {
@@ -86,12 +92,16 @@ namespace Gui.ShipService
             WeaponBlock.gameObject.SetActive(false);
             InnerBlock.gameObject.SetActive(false);
             OuterBlock.gameObject.SetActive(false);
-            
+
             IoBlock.gameObject.SetActive(false);
-            
-            OeBlock.gameObject.SetActive(false);
+
             IeBlock.gameObject.SetActive(false);
-            
+            OeBlock.gameObject.SetActive(false);
+            WeBlock.gameObject.SetActive(false);
+            WiBlock.gameObject.SetActive(false);
+            WoBlock.gameObject.SetActive(false);
+            AllBlock.gameObject.SetActive(false);
+
             EngineBlock.gameObject.SetActive(false);
             CustomBlock.gameObject.SetActive(false);
             Cleanup();
@@ -126,22 +136,18 @@ namespace Gui.ShipService
 
         private BlockViewModel CreateBlock(/*ShipLayout.LayoutElement cell*/CellType cell)
         {
-			switch (cell)
+            switch (cell)
             {
                 case CellType.Outer:
                     return GameObject.Instantiate<BlockViewModel>(OuterBlock);
                 case CellType.Inner:
                     return GameObject.Instantiate<BlockViewModel>(InnerBlock);
-				case CellType.Weapon:
-				case CellType.WeaponEngine:
-				case CellType.WeaponInner:
-				case CellType.WeaponOuter:
-                case CellType.All:
+                case CellType.Weapon:
                 case Layout.CustomWeaponCell:
-					var item = GameObject.Instantiate<BlockViewModel>(WeaponBlock);
-					//item.Label.text = string.IsNullOrEmpty(cell.WeaponClass) ? "•" : cell.WeaponClass;
-					return item;
-				case CellType.Engine:
+                    var item = GameObject.Instantiate<BlockViewModel>(WeaponBlock);
+                    //item.Label.text = string.IsNullOrEmpty(cell.WeaponClass) ? "•" : cell.WeaponClass;
+                    return item;
+                case CellType.Engine:
                     return GameObject.Instantiate<BlockViewModel>(EngineBlock);
 
                 case CellType.OuterEngine:
@@ -153,14 +159,22 @@ namespace Gui.ShipService
                 case CellType.InnerEngine:
                     return GameObject.Instantiate<BlockViewModel>(IeBlock);
 
-                
+                case CellType.All:
+                    return GameObject.Instantiate<BlockViewModel>(AllBlock);
+
+                case CellType.WeaponEngine:
+                    return GameObject.Instantiate<BlockViewModel>(WeBlock);
+                case CellType.WeaponInner:
+                    return GameObject.Instantiate<BlockViewModel>(WiBlock);
+                case CellType.WeaponOuter:
+                    return GameObject.Instantiate<BlockViewModel>(WoBlock);
 
 
                 case Layout.CustomizableCell:
-					return GameObject.Instantiate<BlockViewModel>(CustomBlock);
-			}
+                    return GameObject.Instantiate<BlockViewModel>(CustomBlock);
+            }
 
-			return null;
+            return null;
         }
 
         private void SetBlockLayout(RectTransform item, int x, int y, int size)
@@ -183,9 +197,12 @@ namespace Gui.ShipService
                     child == EngineBlock.transform ||
 
                     child == IoBlock.transform ||
-
                     child == OeBlock.transform ||
                     child == IeBlock.transform ||
+                    child == WeBlock.transform ||
+                    child == WoBlock.transform ||
+                    child == WiBlock.transform ||
+                    child == AllBlock.transform ||
 
                     child == CustomBlock.transform ||
                     child == Selection.transform ||

--- a/Assets/Scripts/Gui/ShipService/ShipLayoutPanel.cs
+++ b/Assets/Scripts/Gui/ShipService/ShipLayoutPanel.cs
@@ -24,12 +24,12 @@ namespace Gui.ShipService
 
         public BlockViewModel IoBlock;
 
-        public BlockViewModel OeBlock;
-        public BlockViewModel IeBlock;
+        public BlockViewModel OuterEngineBlock;
+        public BlockViewModel InnerEngineBlock;
 
-        public BlockViewModel WeBlock;
-        public BlockViewModel WoBlock;
-        public BlockViewModel WiBlock;
+        public BlockViewModel WeaponEngineBlock;
+        public BlockViewModel WeaponOuterBlock;
+        public BlockViewModel WeaponInnerBlock;
 
         public BlockViewModel AllBlock;
 
@@ -95,11 +95,11 @@ namespace Gui.ShipService
 
             IoBlock.gameObject.SetActive(false);
 
-            IeBlock.gameObject.SetActive(false);
-            OeBlock.gameObject.SetActive(false);
-            WeBlock.gameObject.SetActive(false);
-            WiBlock.gameObject.SetActive(false);
-            WoBlock.gameObject.SetActive(false);
+            InnerEngineBlock.gameObject.SetActive(false);
+            OuterEngineBlock.gameObject.SetActive(false);
+            WeaponEngineBlock.gameObject.SetActive(false);
+            WeaponInnerBlock.gameObject.SetActive(false);
+            WeaponOuterBlock.gameObject.SetActive(false);
             AllBlock.gameObject.SetActive(false);
 
             EngineBlock.gameObject.SetActive(false);
@@ -151,23 +151,23 @@ namespace Gui.ShipService
                     return GameObject.Instantiate<BlockViewModel>(EngineBlock);
 
                 case CellType.OuterEngine:
-                    return GameObject.Instantiate<BlockViewModel>(OeBlock);
+                    return GameObject.Instantiate<BlockViewModel>(OuterEngineBlock);
 
                 case CellType.InnerOuter:
                     return GameObject.Instantiate<BlockViewModel>(IoBlock);
 
                 case CellType.InnerEngine:
-                    return GameObject.Instantiate<BlockViewModel>(IeBlock);
+                    return GameObject.Instantiate<BlockViewModel>(InnerEngineBlock);
 
                 case CellType.All:
                     return GameObject.Instantiate<BlockViewModel>(AllBlock);
 
                 case CellType.WeaponEngine:
-                    return GameObject.Instantiate<BlockViewModel>(WeBlock);
+                    return GameObject.Instantiate<BlockViewModel>(WeaponEngineBlock);
                 case CellType.WeaponInner:
-                    return GameObject.Instantiate<BlockViewModel>(WiBlock);
+                    return GameObject.Instantiate<BlockViewModel>(WeaponInnerBlock);
                 case CellType.WeaponOuter:
-                    return GameObject.Instantiate<BlockViewModel>(WoBlock);
+                    return GameObject.Instantiate<BlockViewModel>(WeaponOuterBlock);
 
 
                 case Layout.CustomizableCell:
@@ -197,11 +197,11 @@ namespace Gui.ShipService
                     child == EngineBlock.transform ||
 
                     child == IoBlock.transform ||
-                    child == OeBlock.transform ||
-                    child == IeBlock.transform ||
-                    child == WeBlock.transform ||
-                    child == WoBlock.transform ||
-                    child == WiBlock.transform ||
+                    child == OuterEngineBlock.transform ||
+                    child == InnerEngineBlock.transform ||
+                    child == WeaponEngineBlock.transform ||
+                    child == WeaponOuterBlock.transform ||
+                    child == WeaponInnerBlock.transform ||
                     child == AllBlock.transform ||
 
                     child == CustomBlock.transform ||


### PR DESCRIPTION
Performs this: https://github.com/PavelZinchenko/event-horizon-main/issues/430

Adds all 2-type slots that dont currently exist.
Engine/Weapon has an id of '.', the rest are numbers

Adds Any slot type (id 'a')

Requires https://github.com/PavelZinchenko/event-horizon-modules/pull/4 for rendering and some more little changes.